### PR TITLE
Reduce the amount of instance variables

### DIFF
--- a/src/org/oastem/frc/strong/Robot.java
+++ b/src/org/oastem/frc/strong/Robot.java
@@ -202,13 +202,12 @@ public class Robot extends SampleRobot {
 	public void operatorControl() {
 		stateOfArm = CALIBRATE_STATE;
 		startTeleopTime = System.currentTimeMillis();
-		boolean stop = false;
 		released = false;
 
 		gyro.resetGyro();
-		int what = 0; // Spring insisted
+		int ticks = 0; // Spring insisted
 		while (isOperatorControl() && isEnabled()) {
-			dash.putNumber("Ticks", what++);
+			dash.putNumber("Ticks", ticks++);
 			dash.putBoolean("Speed Toggle", speedToggle);
 			dash.putNumber("Gyro Value:", gyro.getGyroAngle());
 			dash.putNumber("Accelerometer X Value: ", gyro.getAccelX());
@@ -248,40 +247,38 @@ public class Robot extends SampleRobot {
 			eStop2Pressed = pad.getStartButton();
 
 			if (eStop1Pressed && eStop2Pressed)
-				stop = true;
+				continue;
 
 			// "Arcade" Drive
 
-			if (!stop) {
-				if (pad.checkDPad(0)) {
-					talonDrive.driveStraight(70 * scaleTrigger(slowTrigger));
-				} else if (pad.checkDPad(1)) {
-					talonDrive.faketankDrive(scaleTrigger(1.0), scaleTrigger(0));
-				} else if (pad.checkDPad(2)) {
-					talonDrive.faketankDrive(scaleTrigger(1.0), -scaleTrigger(1.0));
-				} else if (pad.checkDPad(3)) {
-					talonDrive.faketankDrive(scaleTrigger(0), -scaleTrigger(1.0));
-				} else if (pad.checkDPad(4)) {
-					talonDrive.driveStraight(-60 * scaleTrigger(slowTrigger));
-				} else if (pad.checkDPad(5)) {
-					talonDrive.faketankDrive(-scaleTrigger(1.0), scaleTrigger(0));
-				} else if (pad.checkDPad(6)) {
-					talonDrive.faketankDrive(-scaleTrigger(1.0), scaleTrigger(1.0));
-				} else if (pad.checkDPad(7)) {
-					talonDrive.faketankDrive(scaleTrigger(0), scaleTrigger(1.0));
-				} else
-					motorDrive();
-				doArm();
-				
-				if (!pad.checkDPad(0) || !pad.checkDPad(4))
-					talonDrive.resetTick();
+			if (pad.checkDPad(0)) {
+				talonDrive.driveStraight(70 * scaleTrigger(slowTrigger));
+			} else if (pad.checkDPad(1)) {
+				talonDrive.faketankDrive(scaleTrigger(1.0), scaleTrigger(0));
+			} else if (pad.checkDPad(2)) {
+				talonDrive.faketankDrive(scaleTrigger(1.0), -scaleTrigger(1.0));
+			} else if (pad.checkDPad(3)) {
+				talonDrive.faketankDrive(scaleTrigger(0), -scaleTrigger(1.0));
+			} else if (pad.checkDPad(4)) {
+				talonDrive.driveStraight(-60 * scaleTrigger(slowTrigger));
+			} else if (pad.checkDPad(5)) {
+				talonDrive.faketankDrive(-scaleTrigger(1.0), scaleTrigger(0));
+			} else if (pad.checkDPad(6)) {
+				talonDrive.faketankDrive(-scaleTrigger(1.0), scaleTrigger(1.0));
+			} else if (pad.checkDPad(7)) {
+				talonDrive.faketankDrive(scaleTrigger(0), scaleTrigger(1.0));
+			} else
+				motorDrive();
+			doArm();
+			
+			if (!pad.checkDPad(0) || !pad.checkDPad(4))
+				talonDrive.resetTick();
 
-				/*
-				 * if (armUpPressed){ armMotor.set(1); } else if
-				 * (armDownPressed){ armMotor.set(-0.65); } else
-				 * armMotor.set(0);
-				 */
-			}
+			/*
+			 * if (armUpPressed){ armMotor.set(1); } else if
+			 * (armDownPressed){ armMotor.set(-0.65); } else
+			 * armMotor.set(0);
+			 */
 		}
 	}
 

--- a/src/org/oastem/frc/strong/Robot.java
+++ b/src/org/oastem/frc/strong/Robot.java
@@ -99,8 +99,6 @@ public class Robot extends SampleRobot {
 	private boolean speedButtonPressed;
 	private boolean straightPressed1;
 	private boolean straightPressed2;
-	private boolean eStop1Pressed;
-	private boolean eStop2Pressed;
 	private boolean armPressed = false;
 
 	public Robot() {
@@ -243,10 +241,10 @@ public class Robot extends SampleRobot {
 			activateAssistButtonPressed = pad.getXButton();
 			speedButtonPressed = pad.getAButton();
 			manualButtonPressed = pad.getBButton();
-			eStop1Pressed = pad.getBackButton();
-			eStop2Pressed = pad.getStartButton();
 
-			if (eStop1Pressed && eStop2Pressed)
+			// Check for emergency stop controller combination:
+			// tapping both the back and start button.
+			if (pad.getBackButton() && pad.getStartButton())
 				continue;
 
 			// "Arcade" Drive


### PR DESCRIPTION
There comes a point where you have so many instance variables that they become kind of useless, since you're bogged down wondering "...do I have an instance variable for this already?"

I've only changed very little but there's a lot of architectural changes that could be made to simplify the code and enhance its readability - for example, a shell class that holds all the configuration variables.
